### PR TITLE
refs #4678

### DIFF
--- a/src/Eccube/Controller/Admin/Order/EditController.php
+++ b/src/Eccube/Controller/Admin/Order/EditController.php
@@ -629,7 +629,7 @@ class EditController extends AbstractController
             foreach ($Products as $Product) {
                 /* @var $builder \Symfony\Component\Form\FormBuilderInterface */
                 $builder = $this->formFactory->createNamedBuilder('', AddCartType::class, null, [
-                    'product' => $this->productRepository->findWithSortedClassCategories($Product->getId()),
+                    'product' => $Product,
                 ]);
                 $addCartForm = $builder->getForm();
                 $forms[$Product->getId()] = $addCartForm->createView();

--- a/src/Eccube/Repository/ProductRepository.php
+++ b/src/Eccube/Repository/ProductRepository.php
@@ -66,7 +66,7 @@ class ProductRepository extends AbstractRepository
     public function findWithSortedClassCategories($productId)
     {
         $qb = $this->createQueryBuilder('p');
-        $qb
+        $qb->addSelect(['pc', 'cc1', 'cc2', 'pi', 'pt'])
             ->innerJoin('p.ProductClasses', 'pc')
             ->leftJoin('pc.ClassCategory1', 'cc1')
             ->leftJoin('pc.ClassCategory2', 'cc2')


### PR DESCRIPTION
@izayoi256 修正ありがとうございます。

テストをしてみたのですが、`addSelect` がないとソート順が保持されないようで、フロントの商品詳細画面の商品規格がソートされなくなってしまいました。
`@orderBy` アノテーションでのソートも試みましたが、うまくいかず。
管理画面の機能ですので、エラーが発生することに比べれば商品規格がソートされている重要性は落ちるのではないかと思い、ソートしないよう修正して見ました。
